### PR TITLE
Fix final class property key paths.

### DIFF
--- a/Sources/SE0000_KeyPathReflection/KeyPathInitialization.swift
+++ b/Sources/SE0000_KeyPathReflection/KeyPathInitialization.swift
@@ -115,13 +115,12 @@ func getKeyPathType(
   
   func openRoot<Root>(_: Root.Type) -> AnyKeyPath.Type {
     func openLeaf<Value>(_: Value.Type) -> AnyKeyPath.Type {
-      switch root.kind {
-      case .struct:
-        return leaf.flags.isVar ? WritableKeyPath<Root, Value>.self
-                                : KeyPath<Root, Value>.self
-      case .class:
-        return ReferenceWritableKeyPath<Root, Value>.self
+      if leaf.flags.isVar {
+        return root.kind == .class
+          ? ReferenceWritableKeyPath<Root, Value>.self
+          : WritableKeyPath<Root, Value>.self
       }
+      return KeyPath<Root, Value>.self
     }
     
     return _openExistential(leafType, do: openLeaf)

--- a/Tests/SE0000_KeyPathReflectionTests/SE0000_KeyPathReflectionTests.swift
+++ b/Tests/SE0000_KeyPathReflectionTests/SE0000_KeyPathReflectionTests.swift
@@ -4,9 +4,11 @@ import XCTest
 private protocol Protocol {}
 extension Int: Protocol {}
 
-private class Class {
+private final class FinalClass {
+  let float: Float = 0
   var int: Int = 0
-  weak var cls: Class? = nil
+  // FIXME: Weak and unowned fields are not supported.
+  // weak var cls: Class? = nil
 }
 
 private struct Struct<T: Equatable> {
@@ -44,16 +46,15 @@ enum StoredPropertyKeyPaths {
   }
 
   static func testClass() throws {
-    // FIXME: Class property iteration fails.
-    /*
-    let allKeyPaths = Reflection.allStoredPropertyKeyPaths(for: Class.self)
-    XCTAssertEqual(allKeyPaths, [\Class.int, \Class.cls])
+    let allKeyPaths = Reflection.allKeyPaths(for: FinalClass.self)
+    XCTAssertEqual(allKeyPaths, [\FinalClass.float, \FinalClass.int])
 
-    let allNamedKeyPaths = Reflection.allNamedStoredPropertyKeyPaths(
-      for: Class.self)
+    let allNamedKeyPaths = Reflection.allNamedKeyPaths(
+      for: FinalClass.self)
     assertNamedKeyPathsEqual(
-      allNamedKeyPaths, [("int", \Class.int), ("cls", \Class.cls)])
-    */
+      allNamedKeyPaths, [("float", \FinalClass.float), ("int", \FinalClass.int)])
+
+    // FIXME: Handle and test non-final class properties and weak/unowned properties.
   }
 }
 
@@ -75,16 +76,15 @@ enum CustomKeyPaths {
   }
 
   static func testClass() throws {
-    // FIXME: Class property iteration fails.
-    /*
-    let c = Class()
+    let c = FinalClass()
     let allKeyPaths = Reflection.allKeyPaths(for: c)
-    XCTAssertEqual(allKeyPaths, [\Class.int, \Class.cls])
+    XCTAssertEqual(allKeyPaths, [\FinalClass.float, \FinalClass.int])
 
     let allNamedKeyPaths = Reflection.allNamedKeyPaths(for: c)
     assertNamedKeyPathsEqual(
-      allNamedKeyPaths, [("int", \Class.int), ("cls", \Class.cls)])
-    */
+      allNamedKeyPaths, [("float", \FinalClass.float), ("int", \FinalClass.int)])
+
+    // FIXME: Handle and test non-final class properties and weak/unowned properties.
   }
 
   static func testOptional() throws {


### PR DESCRIPTION
Class properties are not always reference-writable. Key paths to `let` properties are just `KeyPath`.

cc @Azoy