### PR TITLE
[Reflection] Support arm64e by handling pointer authentication.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,13 +23,13 @@ let package = Package(
   dependencies: [
   ],
   targets: [
-    .target(
-      name: "KeyPathReflection_CShims",
-      dependencies: []
-    ),
+    .target(name: "KeyPathReflection_CShims"),
     .target(
       name: "SE0000_KeyPathReflection",
-      dependencies: ["KeyPathReflection_CShims"]
+      dependencies: ["KeyPathReflection_CShims"],
+      swiftSettings: [
+        .unsafeFlags(["-parse-stdlib"])
+      ]
     ),
     .testTarget(
       name: "SE0000_KeyPathReflectionTests",

--- a/Sources/SE0000_KeyPathReflection/KeyPathIterable.swift
+++ b/Sources/SE0000_KeyPathReflection/KeyPathIterable.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Swift
+
 // An implementation detail of `KeyPathIterable`; do not use this protocol
 // directly.
 public protocol _KeyPathIterableBase {

--- a/Sources/SE0000_KeyPathReflection/Reflection.swift
+++ b/Sources/SE0000_KeyPathReflection/Reflection.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Swift
+
 public enum Reflection {
   /// Returns the collection of all key paths of this type.
   ///


### PR DESCRIPTION
Currently this library crashes on arm64e platforms because type context descriptor pointers on arm64e are signed with the process-independent data (DA) key.  This patch adds `PointerAuthenticatedLayoutWrapper` which allows type context descriptors, field descriptors, and field records to store a signed pointer.  The `pointer` getter will strip the signature.

Tested on iOS arm64e and macOS x86_64.