### PR TITLE
[Reflection] Support reflecting existentials.

### DIFF
--- a/Sources/SE0000_KeyPathReflection/Reflection.swift
+++ b/Sources/SE0000_KeyPathReflection/Reflection.swift
@@ -21,15 +21,38 @@ public enum Reflection {
     guard let metadata = getMetadata(for: type) as? TypeMetadata else {
       return []
     }
-    
+
     var result = [PartialKeyPath<T>]()
     result.reserveCapacity(metadata.contextDescriptor.fields.numFields)
-    
+
     for i in 0 ..< metadata.contextDescriptor.fields.numFields {
       let keyPath = createKeyPath(root: metadata, leaf: i) as! PartialKeyPath<T>
       result.append(keyPath)
     }
     
+    return result
+  }
+
+  /// Returns the collection of all key paths of the existential metatype's
+  /// underlying type.
+  ///
+  /// - Parameter type: The static type to return the stored key paths of.
+  /// - Returns: An array of partial key paths for this type.
+  public static func allKeyPaths(
+    forUnderlyingTypeOf type: Any.Type
+  ) -> [AnyKeyPath] {
+    guard let metadata = getMetadata(for: type) as? TypeMetadata else {
+      return []
+    }
+
+    var result = [AnyKeyPath]()
+    result.reserveCapacity(metadata.contextDescriptor.fields.numFields)
+
+    for i in 0 ..< metadata.contextDescriptor.fields.numFields {
+      let keyPath = createKeyPath(root: metadata, leaf: i)
+      result.append(keyPath)
+    }
+
     return result
   }
   
@@ -47,6 +70,20 @@ public enum Reflection {
     
     // Otherwise, return stored property key paths.
     return allKeyPaths(for: T.self)
+  }
+
+  /// Returns the collection of all key paths of this value.
+  ///
+  /// - Parameter value: A value of any type to return the stored key paths of.
+  /// - Returns: An array of partial key paths for this value.
+  public static func allKeyPaths(for value: Any) -> [AnyKeyPath] {
+    // If the value conforms to `_KeyPathIterableBase`, return `allKeyPaths`.
+    if let keyPathIterable = value as? _KeyPathIterableBase {
+      return keyPathIterable._allKeyPathsTypeErased
+    }
+
+    // Otherwise, return stored property key paths.
+    return allKeyPaths(forUnderlyingTypeOf: type(of: value))
   }
   
   /// Returns the collection of all named key paths of this type.
@@ -72,6 +109,30 @@ public enum Reflection {
     
     return result
   }
+
+  /// Returns the collection of all named key paths of this type.
+  ///
+  /// - Parameter value: A value of any type to return the stored key paths of.
+  /// - Returns: An array of tuples with both the name and partial key path
+  ///            for this value.
+  public static func allNamedKeyPaths(
+    forUnderlyingTypeOf type: Any.Type
+  ) -> [(name: String, keyPath: AnyKeyPath)] {
+    guard let metadata = getMetadata(for: type) as? TypeMetadata else {
+      return []
+    }
+
+    var result = [(name: String, keyPath: AnyKeyPath)]()
+    result.reserveCapacity(metadata.contextDescriptor.fields.numFields)
+
+    for i in 0 ..< metadata.contextDescriptor.fields.numFields {
+      let name = metadata.contextDescriptor.fields.records[i].name
+      let keyPath = createKeyPath(root: metadata, leaf: i)
+      result.append((name: name, keyPath: keyPath))
+    }
+
+    return result
+  }
   
   /// Returns the collection of all named key paths of this value.
   ///
@@ -91,5 +152,23 @@ public enum Reflection {
     
     // Otherwise, return stored property key paths.
     return allNamedKeyPaths(for: T.self)
+  }
+
+  /// Returns the collection of all named key paths of this value.
+  ///
+  /// - Parameter value: A value of any type to return the stored key paths of.
+  /// - Returns: An array of tuples with both the name and partial key path
+  ///            for this value.
+  public static func allNamedKeyPaths(
+    for value: Any
+  ) -> [(name: String, keyPath: AnyKeyPath)] {
+    // If the value conforms to `_KeyPathIterableBase`, return
+    // `allNamedKeyPaths`.
+    if let keyPathIterable = value as? _KeyPathIterableBase {
+      return keyPathIterable._allNamedKeyPathsTypeErased.map { ($0, $1) }
+    }
+
+    // Otherwise, return stored property key paths.
+    return allNamedKeyPaths(forUnderlyingTypeOf: type(of: value))
   }
 }


### PR DESCRIPTION
Add support for reflecting existential values and existential metatypes.

New public methods added in `Reflection`:
```swift
static func allKeyPaths(forUnderlyingTypeOf type: Any.Type) -> [AnyKeyPath]
static func allKeyPaths(for value: Any) -> [AnyKeyPath]
static func allNamedKeyPaths(forUnderlyingTypeOf type: Any.Type) -> [(name: String, keyPath: AnyKeyPath)]
static func allNamedKeyPaths(for value: Any) -> [(name: String, keyPath: AnyKeyPath)]
```

Note:
1. Adding methods for `Any` and `Any.Type` is necessary because key paths constructed for existentials cannot use `PartialKeyPath<Any>` as the type — their base type is the underlying dynamic type, not `Any`.
2. The argument label `forUnderlyingTypeOf:` cannot be `for:` because type checking overload resolution prefers existential metatypes over generic metatypes.